### PR TITLE
Fix katello rubocop to use its own bundle with isolated gem path

### DIFF
--- a/theforeman.org/pipelines/release/source/katello.groovy
+++ b/theforeman.org/pipelines/release/source/katello.groovy
@@ -60,8 +60,12 @@ pipeline {
                     }
                 }
                 stage('rubocop') {
+                    environment {
+                        BUNDLE_PATH = "${env.WORKSPACE}/.rubocop_bundle"
+                    }
                     steps {
-                        bundleExec(ruby, 'rubocop --parallel', 'foreman/Gemfile')
+                        bundleInstall(ruby)
+                        bundleExec(ruby, 'rubocop --parallel')
                     }
                 }
                 stage('react-ui') {


### PR DESCRIPTION
## Summary
- Run rubocop from workspace root using katello's own Gemfile, matching [GitHub CI](https://github.com/Katello/katello/blob/master/.github/workflows/ruby.yml#L16-L21)
- Isolate gems via `BUNDLE_PATH` to prevent Rack 2/3 conflicts with Foreman's parallel bundle at `~/.rubygems`

Addresses ekohl's [review](https://github.com/theforeman/jenkins-jobs/pull/578#pullrequestreview-4435257864) — GH CI runs rubocop standalone with katello's bundle, not Foreman's.